### PR TITLE
add bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,4 +22,18 @@
     "type": "git",
     "url": "https://github.com/xc-jp/purescript-protobuf.git"
   }
+  "dependencies": {
+    "purescript-parsing": "^5.0.3",
+    "purescript-arraybuffer-types": "^2.0.0",
+    "purescript-arraybuffer": "^10.0.2",
+    "purescript-uint": "^5.1.4",
+    "purescript-text-encoding": "^1.0.0",
+    "purescript-longs": "^0.1.1",
+    "purescript-node-streams": "^4.0.1",
+    "purescript-node-process": "^7.0.0",
+    "purescript-node-buffer": "^6.0.0",
+    "purescript-node-path": "^3.0.0",
+    "purescript-arraybuffer-builder": "jamesdbrock/purescript-arraybuffer-builder#1.1.0",
+    "purescript-parsing-dataview": "jamesdbrock/purescript-parsing-dataview#1.1.1"
+  }
 }


### PR DESCRIPTION
pushing docs without publishing version:

```
馬 ~/Code/purescript-protobuf heads/v0.9.1 (129) $ git tag -d v0.9.1
Deleted tag 'v0.9.1' (was c03e28c)
馬 ~/Code/purescript-protobuf v0.9.1 $ git tag v0.9.1
馬 ~/Code/purescript-protobuf heads/v0.9.1 $ pulp publish --no-push
warning: refname 'v0.9.1' is ambiguous.
Checking your package is registered in purescript/registry... ok
Publishing purescript-protobuf at v0.9.1. Is this ok? [y/n] y
* Uploading documentation to Pursuit...
* Done.
* You can view your package's documentation at: https://pursuit.purescript.org/packages/purescript-protobuf/0.9.1
```

adding non bower registry packages:

```
馬 ~/Code/purescript-protobuf bower-file $ bower i -S jamesdbrock/purescript-arraybuffer-builder@1.1.0
bower not-cached    https://github.com/jamesdbrock/purescript-arraybuffer-builder.git#1.1.0
bower resolve       https://github.com/jamesdbrock/purescript-arraybuffer-builder.git#1.1.0
bower download      https://github.com/jamesdbrock/purescript-arraybuffer-builder/archive/v1.1.0.tar.gz
bower extract       purescript-arraybuffer-builder#1.1.0 archive.tar.gz
bower resolved      https://github.com/jamesdbrock/purescript-arraybuffer-builder.git#1.1.0
bower install       purescript-arraybuffer-builder#1.1.0
purescript-arraybuffer-builder#1.1.0 bower_components/purescript-arraybuffer-builder
├── purescript-arraybuffer#10.0.2
└── purescript-arraybuffer-types#2.0.0
```