### PR TITLE
Optimize decodeArray by using typed arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,9 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "long": "^4.0.0"
+  },
+  "devDependencies": {
+    "purescript-language-server": "^0.15.0",
+    "purty": "^7.0.0"
   }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -14,7 +14,7 @@ pkgs.mkShell {
   ];
   shellHook = ''
   shopt -s globstar # Need for globbing packagePath in vscode PureScript IDE
-  export PATH="./bin:$PATH"   # PATH to protoc-gen-purescript
+  export PATH="./bin:./node_modules/.bin:$PATH"   # PATH to protoc-gen-purescript
   echo "Purescript Protobuf development environment."
   protoc --version
   echo -n "purs "

--- a/src/Protobuf/Decode.js
+++ b/src/Protobuf/Decode.js
@@ -11,3 +11,25 @@ exports._decodeArray = function(f) {
     };
   };
 }
+
+// Check whether the number 1 updates the first or last byte in a 4 byte array.
+// This determines endianness.
+//
+// The function memoizes the result so that subsequent calls don't need to
+// perform the check again
+exports._isBigEndian = function () {
+  var computed = false;
+  var bigEndian;
+  return function() {
+    if(computed === true) {
+      return bigEndian;
+    } else {
+      const array = new Uint8Array(4);
+      const view = new Uint32Array(array.buffer);
+      bigEndian = !((view[0] = 1) & array[0]);
+      computed = true;
+    }
+    return bigEndian;
+  }
+}
+

--- a/src/Protobuf/Decode.js
+++ b/src/Protobuf/Decode.js
@@ -1,0 +1,13 @@
+exports._decodeArray = function(f) {
+  return function(n) {
+    return function () {
+      var a = new Array(n);
+      var l = a.length;
+      var i;
+      for (i=0;i<l;i+=1) {
+        a[i] = f(i)();
+      }
+      return a;
+    };
+  };
+}

--- a/src/Protobuf/Decode.purs
+++ b/src/Protobuf/Decode.purs
@@ -3,39 +3,52 @@
 -- | You almost never need to import this module.
 -- | See package README for explanation.
 module Protobuf.Decode
-( double
-, float
-, int32
-, int64
-, uint32
-, uint64
-, sint32
-, sint64
-, fixed32
-, fixed64
-, sfixed32
-, sfixed64
-, bool
-, string
-, bytes
-, module Protobuf.Decode32
-, module Protobuf.Decode64
-) where
+  ( double
+  , doubleArray
+  , float
+  , floatArray
+  , int32
+  , int64
+  , uint32
+  , uint64
+  , sint32
+  , sint64
+  , fixed32
+  , fixed32Array
+  , fixed64
+  , fixed64Array
+  , sfixed32
+  , sfixed32Array
+  , sfixed64
+  , sfixed64Array
+  , bool
+  , string
+  , bytes
+  , module Protobuf.Decode32
+  , module Protobuf.Decode64
+  ) where
 
 import Prelude
-
+import Control.Apply (lift2)
+import Control.Monad.Except (ExceptT(..))
+import Control.Monad.State (StateT(..))
 import Control.Monad.Trans.Class (lift)
 import Data.ArrayBuffer.ArrayBuffer as AB
+import Data.ArrayBuffer.DataView (AProxy(..), getFloat32le, getFloat64le, getInt32le, getUint32le)
 import Data.ArrayBuffer.DataView as DV
 import Data.ArrayBuffer.Typed as AT
-import Data.ArrayBuffer.Types (DataView, Uint8Array)
+import Data.ArrayBuffer.Types (ByteLength, ByteOffset, DataView, Uint8Array, kind ArrayViewType)
+import Data.ArrayBuffer.Types as ArrayTypes
+import Data.ArrayBuffer.ValueMapping (class BinaryValue, class BytesPerValue, class ShowArrayViewType)
 import Data.Either (Either(..))
 import Data.Float32 (Float32)
-import Data.Int (Radix, radix, toStringAs)
 import Data.Long.Internal (Long, Signed, Unsigned, fromLowHighBits, highBits, lowBits, unsignedToSigned)
-import Data.Long.Internal as Long
-import Data.Maybe (Maybe(..), fromJust)
+import Data.Maybe (Maybe, fromJust)
+import Data.String (joinWith)
+import Data.Symbol (class IsSymbol, SProxy(..), reflectSymbol)
 import Data.TextDecoding (decodeUtf8)
+import Data.Tuple (Tuple(..))
+import Data.Typelevel.Num (class Nat, D8, toInt')
 import Data.UInt (UInt)
 import Data.UInt as UInt
 import Effect (Effect)
@@ -44,8 +57,10 @@ import Partial.Unsafe (unsafePartial)
 import Protobuf.Common (Bytes(..))
 import Protobuf.Decode32 (varint32, zigzag32, tag32)
 import Protobuf.Decode64 (varint64, zigzag64)
-import Text.Parsing.Parser (ParserT, fail)
+import Text.Parsing.Parser (ParseError(..), ParseState(..), ParserT(..), fail)
 import Text.Parsing.Parser.DataView as Parse
+import Text.Parsing.Parser.Pos (Position(..))
+import Type.Proxy (Proxy(..))
 
 -- | __double__
 -- | [Scalar Value Type](https://developers.google.com/protocol-buffers/docs/proto3#scalar)
@@ -57,28 +72,135 @@ double = Parse.anyFloat64le
 float :: forall m. MonadEffect m => ParserT DataView m Float32
 float = Parse.anyFloat32le
 
+-- | __repeated packed float__
+floatArray :: forall m. MonadEffect m => Int -> ParserT DataView m (Array Float32)
+floatArray = typedArray (AProxy :: AProxy ArrayTypes.Float32) getFloat32le
+
+-- | __repeated packed double__
+doubleArray :: forall m. MonadEffect m => Int -> ParserT DataView m (Array Number)
+doubleArray = typedArray (AProxy :: AProxy ArrayTypes.Float64) getFloat64le
+
+-- | __repeated packed sfixed32__
+sfixed32Array :: forall m. MonadEffect m => Int -> ParserT DataView m (Array Int)
+sfixed32Array = typedArray (AProxy :: AProxy ArrayTypes.Int32) getInt32le
+
+foreign import data BigInt64 :: ArrayViewType
+
+instance bytesPerValueBigInt64 :: BytesPerValue BigInt64 D8
+
+instance binaryValueBigInt64 :: BinaryValue BigInt64 (Long Signed)
+
+instance showArrayViewBigInt64 :: ShowArrayViewType BigInt64 "long signed"
+
+getLongle :: DataView -> Int -> Effect (Maybe (Long Signed))
+getLongle dv idx = do
+  lo <- getInt32le dv idx
+  hi <- getInt32le dv (idx + 4)
+  pure $ lift2 fromLowHighBits lo hi
+
+-- | __repeated packed sfixed64__
+sfixed64Array :: forall m. MonadEffect m => Int -> ParserT DataView m (Array (Long Signed))
+sfixed64Array = typedArray (AProxy :: AProxy BigInt64) getLongle
+
+foreign import data BigUInt64 :: ArrayViewType
+
+instance bytesPerValueBigUInt64 :: BytesPerValue BigUInt64 D8
+
+instance binaryValueBigUInt64 :: BinaryValue BigUInt64 (Long Unsigned)
+
+instance showArrayViewBigUInt64 :: ShowArrayViewType BigUInt64 "long unsigned"
+
+getULongle :: DataView -> Int -> Effect (Maybe (Long Unsigned))
+getULongle dv idx = do
+  lo <- getInt32le dv idx
+  hi <- getInt32le dv (idx + 4)
+  pure $ lift2 fromLowHighBits lo hi
+
+-- | __repeated packed fixed32__
+fixed32Array :: forall m. MonadEffect m => Int -> ParserT DataView m (Array UInt)
+fixed32Array = typedArray (AProxy :: AProxy ArrayTypes.Uint32) getUint32le
+
+-- | __repeated packed fixed64__
+fixed64Array :: forall m. MonadEffect m => Int -> ParserT DataView m (Array (Long Unsigned))
+fixed64Array = typedArray (AProxy :: AProxy BigUInt64) getULongle
+
+foreign import _decodeArray ::
+  forall t. (ByteOffset -> Effect t) -> Int -> Effect (Array t)
+
+-- | Parse a slice of the DataView to an Array given a parser for the
+-- | individual elements
+typedArray ::
+  forall a m b t name.
+  BinaryValue a t =>
+  BytesPerValue a b =>
+  ShowArrayViewType a name =>
+  IsSymbol name =>
+  Nat b =>
+  MonadEffect m =>
+  AProxy a ->
+  (DataView -> ByteOffset -> Effect (Maybe t)) ->
+  ByteLength ->
+  ParserT DataView m (Array t)
+typedArray _ decodeValue n =
+  let
+    byteSize = toInt' (Proxy :: Proxy b)
+
+    name = reflectSymbol (SProxy :: SProxy name)
+  in
+    do
+      unless
+        (n `mod` byteSize == 0)
+        ( pure unit
+            >>= \_ ->
+                fail
+                  $ joinWith " "
+                      [ "byte length not a multiple of"
+                      , show byteSize
+                      , "when parsing"
+                      , name
+                      , "array"
+                      ]
+        )
+      ParserT $ ExceptT
+        $ StateT \state@(ParseState s pos@(Position { line, column }) _) ->
+            let
+              pos' = Position { line, column: column + n }
+
+              -- we assume all indexing into the dataview will be valid given the
+              -- check against the byteLength
+              unsafeDecodeValue i =
+                unsafePartial
+                  $ map fromJust
+                  $ decodeValue s ((i * byteSize) + column - 1)
+            in
+              if column + n - 1 > DV.byteLength s then
+                pure (Tuple (Left (ParseError "index out of bounds" pos')) state)
+              else do
+                x <- liftEffect (_decodeArray unsafeDecodeValue (n `div` byteSize))
+                pure (Tuple (pure x) (ParseState s pos' true))
+
 -- | __int32__
 -- | [Scalar Value Type](https://developers.google.com/protocol-buffers/docs/proto3#scalar)
 int32 :: forall m. MonadEffect m => ParserT DataView m Int
 int32 = do
   n <- varint64
+  -- But this is a problem with the Protobuf spec?
+  -- “If you use int32 or int64 as the type for a negative number, the resulting
+  -- varint is always ten bytes long”
+  -- https://developers.google.com/protocol-buffers/docs/encoding#signed_integers
+  -- So what are we supposed to do if the field type is int32 but the
+  -- decoded varint is too big? There is no guarantee that either negative
+  -- or positive numbers encoded as varints will be in range.
+  -- I suppose we could check that the high bits are all 0
+  -- for positive or all 1 for negative.
+  -- The conformance tests seem to like it if we just throw away
+  -- the hight bits. So that's what we'll do.
+  --
+  -- conformance checker hates this:
+  --   case Long.toInt n of
+  --     Nothing -> fail "int32 value out of range."
+  --     Just x -> pure x
   pure $ lowBits n
-    -- But this is a problem with the Protobuf spec?
-    -- “If you use int32 or int64 as the type for a negative number, the resulting
-    -- varint is always ten bytes long”
-    -- https://developers.google.com/protocol-buffers/docs/encoding#signed_integers
-    -- So what are we supposed to do if the field type is int32 but the
-    -- decoded varint is too big? There is no guarantee that either negative
-    -- or positive numbers encoded as varints will be in range.
-    -- I suppose we could check that the high bits are all 0
-    -- for positive or all 1 for negative.
-    -- The conformance tests seem to like it if we just throw away
-    -- the hight bits. So that's what we'll do.
-    --
-    -- conformance checker hates this:
-    --   case Long.toInt n of
-    --     Nothing -> fail "int32 value out of range."
-    --     Just x -> pure x
 
 -- | __int64__
 -- | [Scalar Value Type](https://developers.google.com/protocol-buffers/docs/proto3#scalar)
@@ -103,12 +225,6 @@ sint32 :: forall m. MonadEffect m => ParserT DataView m Int
 sint32 = do
   n <- zigzag32 <$> varint32
   pure n
-  -- n <- zigzag64 <$> varint64
-  -- -- pure $ lowBits n
-  -- case Long.toInt n of
-  --   -- Nothing -> fail "sint32 value out of range."
-  --   Nothing -> fail $ "\nsint32 value out of range.\n lowBits " <> toStringAs (unsafePartial $ fromJust $ radix 16) (lowBits n) <> "\n highBits " <> toStringAs (unsafePartial $ fromJust $ radix 16) (highBits n)
-  --   Just x -> pure x
 
 -- | __sint64__
 -- | [Scalar Value Type](https://developers.google.com/protocol-buffers/docs/proto3#scalar)
@@ -140,9 +256,10 @@ sfixed64 = fromLowHighBits <$> Parse.anyInt32le <*> Parse.anyInt32le
 bool :: forall m. MonadEffect m => ParserT DataView m Boolean
 bool = do
   x <- varint64
-  if lowBits x == 0 && highBits x == 0
-    then pure false
-    else pure true
+  if lowBits x == 0 && highBits x == 0 then
+    pure false
+  else
+    pure true
 
 -- | __string__
 -- | [Scalar Value Type](https://developers.google.com/protocol-buffers/docs/proto3#scalar)
@@ -153,12 +270,15 @@ string = do
   case decodeUtf8 stringarray of
     Left err -> fail $ "string decodeUtf8 failed. " <> show err
     Right s -> pure s
- where
+  where
   mkTypedArray :: DataView -> Effect Uint8Array
   mkTypedArray dv = do
-    let buffer     = DV.buffer dv
-        byteOffset = DV.byteOffset dv
-        byteLength = DV.byteLength dv
+    let
+      buffer = DV.buffer dv
+
+      byteOffset = DV.byteOffset dv
+
+      byteLength = DV.byteLength dv
     AT.part buffer byteOffset byteLength
 
 -- | __bytes__
@@ -167,8 +287,8 @@ bytes :: forall m. MonadEffect m => ParserT DataView m Bytes
 bytes = do
   len <- UInt.toInt <$> varint32
   dv <- Parse.takeN len
-  let ab = DV.buffer dv
-  let begin = DV.byteOffset dv
+  let
+    ab = DV.buffer dv
+  let
+    begin = DV.byteOffset dv
   pure $ Bytes $ AB.slice begin (begin + len) ab
-
-

--- a/src/ProtocPlugin/Main.purs
+++ b/src/ProtocPlugin/Main.purs
@@ -540,7 +540,7 @@ genFile proto_file (FileDescriptorProto
           , "    x <- Decode.double"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Array.snoc x"
           , "  parseField " <> show fnumber <> " Common.LenDel = Runtime.label \"" <> name' <> " / \" $ do"
-          , "    x <- Runtime.parseLenDel $ Runtime.manyLength Decode.double"
+          , "    x <- Runtime.parseLenDel $ Decode.doubleArray"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Semigroup.append x"
           ]
         go _ FieldDescriptorProto_Label_LABEL_REPEATED FieldDescriptorProto_Type_TYPE_FLOAT _ = Right $ String.joinWith "\n"
@@ -548,7 +548,7 @@ genFile proto_file (FileDescriptorProto
           , "    x <- Decode.float"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Array.snoc x"
           , "  parseField " <> show fnumber <> " Common.LenDel = Runtime.label \"" <> name' <> " / \" $ do"
-          , "    x <- Runtime.parseLenDel $ Runtime.manyLength Decode.float"
+          , "    x <- Runtime.parseLenDel $ Decode.floatArray"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Semigroup.append x"
           ]
         go _ FieldDescriptorProto_Label_LABEL_REPEATED FieldDescriptorProto_Type_TYPE_INT64 _ = Right $ String.joinWith "\n"
@@ -580,7 +580,7 @@ genFile proto_file (FileDescriptorProto
           , "    x <- Decode.fixed64"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Array.snoc x"
           , "  parseField " <> show fnumber <> " Common.LenDel = Runtime.label \"" <> name' <> " / \" $ do"
-          , "    x <- Runtime.parseLenDel $ Runtime.manyLength Decode.fixed64"
+          , "    x <- Runtime.parseLenDel $ Decode.fixed64Array"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Semigroup.append x"
           ]
         go _ FieldDescriptorProto_Label_LABEL_REPEATED FieldDescriptorProto_Type_TYPE_FIXED32 _ = Right $ String.joinWith "\n"
@@ -588,7 +588,7 @@ genFile proto_file (FileDescriptorProto
           , "    x <- Decode.fixed32"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Array.snoc x"
           , "  parseField " <> show fnumber <> " Common.LenDel = Runtime.label \"" <> name' <> " / \" $ do"
-          , "    x <- Runtime.parseLenDel $ Runtime.manyLength Decode.fixed32"
+          , "    x <- Runtime.parseLenDel $ Decode.fixed32Array"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Semigroup.append x"
           ]
         go _ FieldDescriptorProto_Label_LABEL_REPEATED FieldDescriptorProto_Type_TYPE_BOOL _ = Right $ String.joinWith "\n"
@@ -635,7 +635,7 @@ genFile proto_file (FileDescriptorProto
           , "    x <- Decode.sfixed32"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Array.snoc x"
           , "  parseField " <> show fnumber <> " Common.LenDel = Runtime.label \"" <> name' <> " / \" $ do"
-          , "    x <- Runtime.parseLenDel $ Runtime.manyLength Decode.sfixed32"
+          , "    x <- Runtime.parseLenDel $ Decode.sfixed32Array"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Semigroup.append x"
           ]
         go _ FieldDescriptorProto_Label_LABEL_REPEATED FieldDescriptorProto_Type_TYPE_SFIXED64 _ = Right $ String.joinWith "\n"
@@ -643,7 +643,7 @@ genFile proto_file (FileDescriptorProto
           , "    x <- Decode.sfixed64"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Array.snoc x"
           , "  parseField " <> show fnumber <> " Common.LenDel = Runtime.label \"" <> name' <> " / \" $ do"
-          , "    x <- Runtime.parseLenDel $ Runtime.manyLength Decode.sfixed64"
+          , "    x <- Runtime.parseLenDel $ Decode.sfixed64Array"
           , "    pure $ Record.Builder.modify (Symbol.SProxy :: Symbol.SProxy \"" <> fname <> "\") $ Function.flip Semigroup.append x"
           ]
         go _ FieldDescriptorProto_Label_LABEL_REPEATED FieldDescriptorProto_Type_TYPE_SINT32 _ = Right $ String.joinWith "\n"

--- a/test.dhall
+++ b/test.dhall
@@ -19,5 +19,6 @@ in conf //
   , dependencies = conf.dependencies #
     [ "assert"
     , "psci-support"
+    , "minibench"
     ]
   }

--- a/test/Bench.purs
+++ b/test/Bench.purs
@@ -1,0 +1,62 @@
+module Test.Bench where
+
+import Prelude
+
+import Data.Array (range, replicate)
+import Data.ArrayBuffer.ArrayBuffer (byteLength, empty)
+import Data.ArrayBuffer.Builder (execPut)
+import Data.ArrayBuffer.DataView (whole)
+import Data.ArrayBuffer.Typed as Typed
+import Data.ArrayBuffer.Types (Float32Array)
+import Data.Float32 (fromNumber')
+import Data.Foldable (for_)
+import Data.Unfoldable (replicateA)
+import Effect (Effect, forE)
+import Effect.Console (log)
+import Effect.Unsafe (unsafePerformEffect)
+import Performance.Minibench (bench, benchWith)
+import Protobuf.Decode as Decode
+import Protobuf.Encode as Encode
+import Protobuf.Runtime (manyLength)
+import Text.Parsing.Parser (runParserT)
+
+main :: Effect Unit
+main = do
+
+  log "\nWarmup bench"
+  bench \_ -> forE 0 10000 (\_ -> pure unit)
+
+  buf10e3 <- execPut do
+    -- void $ replicateA 10000 $ Encode.float' (fromNumber' 1.0)
+    for_ (range 1 999) $ \_ -> Encode.float' (fromNumber' 1.0)
+
+  log "\nmanyLength float 10e3"
+  benchWith 100 $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf10e3) do
+    manyLength (Decode.float) (byteLength buf10e3)
+
+  -- buf5000 <- execPut do
+  --   for_ (range 1 5000) $ \_ -> Encode.float' (fromNumber' 1.0)
+
+  -- log "\nmanyLength float 5000"
+  -- bench $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf5000) do
+  --   manyLength (Decode.float) (byteLength buf5000)
+
+  buf10e4 <- empty (4*10000)
+  buf10e4Float :: Float32Array <- Typed.whole buf10e4
+  Typed.fill (fromNumber' 1.0) 0 9999 buf10e4Float
+
+  log "\nmanyLength float 10e4"
+  benchWith 100 $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf10e4) do
+    manyLength (Decode.float) (byteLength buf10e4)
+
+  buf10e5 <- empty (4*100000)
+  buf10e5Float :: Float32Array <- Typed.whole buf10e5
+  Typed.fill (fromNumber' 1.0) 0 99999 buf10e5Float
+  -- buf10e5
+    -- void $ replicateA 10000 $ Encode.float' (fromNumber' 1.0)
+    -- for_ (range 1 1000) $ \_ -> Encode.float' (fromNumber' 1.0)
+    -- forE 0 99999 $ \_ ->
+
+  log "\nmanyLength float 10e5"
+  benchWith 100 $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf10e5) do
+    manyLength (Decode.float) (byteLength buf10e5)

--- a/test/Bench.purs
+++ b/test/Bench.purs
@@ -1,8 +1,7 @@
 module Test.Bench where
 
 import Prelude
-
-import Data.Array (range, replicate)
+import Data.Array (range)
 import Data.ArrayBuffer.ArrayBuffer (byteLength, empty)
 import Data.ArrayBuffer.Builder (execPut)
 import Data.ArrayBuffer.DataView (whole)
@@ -10,53 +9,57 @@ import Data.ArrayBuffer.Typed as Typed
 import Data.ArrayBuffer.Types (Float32Array)
 import Data.Float32 (fromNumber')
 import Data.Foldable (for_)
-import Data.Unfoldable (replicateA)
 import Effect (Effect, forE)
 import Effect.Console (log)
 import Effect.Unsafe (unsafePerformEffect)
 import Performance.Minibench (bench, benchWith)
 import Protobuf.Decode as Decode
 import Protobuf.Encode as Encode
-import Protobuf.Runtime (manyLength)
+import Protobuf.Runtime as Runtime
 import Text.Parsing.Parser (runParserT)
 
 main :: Effect Unit
 main = do
-
   log "\nWarmup bench"
   bench \_ -> forE 0 10000 (\_ -> pure unit)
-
-  buf10e3 <- execPut do
-    -- void $ replicateA 10000 $ Encode.float' (fromNumber' 1.0)
-    for_ (range 1 999) $ \_ -> Encode.float' (fromNumber' 1.0)
-
-  log "\nmanyLength float 10e3"
-  benchWith 100 $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf10e3) do
-    manyLength (Decode.float) (byteLength buf10e3)
-
-  -- buf5000 <- execPut do
-  --   for_ (range 1 5000) $ \_ -> Encode.float' (fromNumber' 1.0)
-
-  -- log "\nmanyLength float 5000"
-  -- bench $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf5000) do
-  --   manyLength (Decode.float) (byteLength buf5000)
-
-  buf10e4 <- empty (4*10000)
+  buf10e3 <-
+    execPut do
+      for_ (range 1 999) $ \_ -> Encode.float' (fromNumber' 1.0)
+  log "\nfloatArray 10e3"
+  benchWith 100
+    $ \_ ->
+        void $ unsafePerformEffect
+          $ runParserT (whole buf10e3) (Decode.floatArray (byteLength buf10e3))
+  buf10e4 <- empty (4 * 10000)
   buf10e4Float :: Float32Array <- Typed.whole buf10e4
   Typed.fill (fromNumber' 1.0) 0 9999 buf10e4Float
-
+  log "\nfloatArray 10e4"
+  benchWith 100
+    $ \_ ->
+        void $ unsafePerformEffect
+          $ runParserT (whole buf10e4) (Decode.floatArray (byteLength buf10e4))
   log "\nmanyLength float 10e4"
-  benchWith 100 $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf10e4) do
-    manyLength (Decode.float) (byteLength buf10e4)
-
-  buf10e5 <- empty (4*100000)
+  benchWith 100
+    $ \_ ->
+        void $ unsafePerformEffect
+          $ runParserT (whole buf10e4) (Runtime.manyLength Decode.float (byteLength buf10e4))
+  buf10e5 <- empty (4 * 100000)
   buf10e5Float :: Float32Array <- Typed.whole buf10e5
   Typed.fill (fromNumber' 1.0) 0 99999 buf10e5Float
-  -- buf10e5
-    -- void $ replicateA 10000 $ Encode.float' (fromNumber' 1.0)
-    -- for_ (range 1 1000) $ \_ -> Encode.float' (fromNumber' 1.0)
-    -- forE 0 99999 $ \_ ->
-
+  log "\nfloatArray 10e5"
+  benchWith 100
+    $ \_ ->
+        void $ unsafePerformEffect
+          $ runParserT (whole buf10e5) (Decode.floatArray (byteLength buf10e5))
   log "\nmanyLength float 10e5"
-  benchWith 100 $ \_ -> void $ unsafePerformEffect $ runParserT (whole buf10e5) do
-    manyLength (Decode.float) (byteLength buf10e5)
+  benchWith 100
+    $ \_ ->
+        void $ unsafePerformEffect
+          $ runParserT (whole buf10e5) (Runtime.manyLength Decode.float (byteLength buf10e5))
+  buf10e6 <- empty (4 * 1000000)
+  buf10e6Float :: Float32Array <- Typed.whole buf10e6
+  Typed.fill (fromNumber' 7.0) 0 1000000 buf10e6Float
+  log "\nfloatArray 1e6"
+  benchWith 100 \_ ->
+    unsafePerformEffect do
+      void $ runParserT (whole buf10e6) (Decode.floatArray (byteLength buf10e6))

--- a/test/README.md
+++ b/test/README.md
@@ -8,3 +8,12 @@ of the repo, then:
     protoc --purescript_out=./test/generated test/*.proto
     spago -x test.dhall build
     spago -x test.dhall test
+
+# Benchmarks
+
+To run the benchmarks, run `nix-shell` then:
+
+```
+    npm install
+    spago -x test.dhall run --main Test.Bench
+```


### PR DESCRIPTION
On little-endian systems we can use typed arrays to speed up parsing of repeated packed values.

This PR implements this optimization in a way that falls back to applying a decoder function on each value if the system is big-endian.